### PR TITLE
RA-1298 - Fix Null Pointer exception for Registration Summary page 

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/summary/RegistrationSummaryFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/summary/RegistrationSummaryFragmentController.java
@@ -47,7 +47,7 @@ public class RegistrationSummaryFragmentController {
         if (config.get("appId") !=null ) {
             app = appFrameworkService.getApp((String) config.get("appId"));
         }
-        model.addAttribute("appId", app !=null ? app.getId() : null);
+        model.addAttribute("appId", app !=null ? app.getId() : "referenceapplication.registrationapp.registerPatient");
 
         List<Extension> registrationFragments = appFrameworkService.getExtensionsForCurrentUser("registrationSummary.contentFragments", appContextModel);
         Collections.sort(registrationFragments);

--- a/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegistrationSummaryPageController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegistrationSummaryPageController.java
@@ -47,7 +47,7 @@ public class RegistrationSummaryPageController extends AbstractRegistrationAppPa
 
         patientDomainWrapper.setPatient(patient);
         model.addAttribute("patient", patientDomainWrapper);
-        model.addAttribute("appId", app !=null ? app.getId() : null);
+        model.addAttribute("appId", app !=null ? app.getId() : "referenceapplication.registrationapp.registerPatient");
         model.addAttribute("search", search);
         model.addAttribute("breadcrumbOverride", breadcrumbOverride);
 

--- a/omod/src/main/webapp/fragments/summary/registrationSummary.gsp
+++ b/omod/src/main/webapp/fragments/summary/registrationSummary.gsp
@@ -1,5 +1,5 @@
 <%
-    def returnUrl = "/${contextPath}/registrationapp/registrationSummary.page?patientId=${patient.patient.id}"
+    def returnUrl = "/${contextPath}/registrationapp/registrationSummary.page?patientId=${patient.patient.id}&appId=${appId}"
 
 %>
 
@@ -8,7 +8,7 @@
 <div class="container">
     <div class="dashboard clear">
         <div class="info-container column">
-            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: "registrationapp.registerPatient", sectionId: "demographics"]) }
+            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "demographics"]) }
 
             <% if (registrationFragments) {
                 registrationFragments.each { %>
@@ -18,7 +18,7 @@
         </div>
 
         <div class="info-container column">
-            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: "registrationapp.registerPatient", sectionId: "contactInfo"]) }
+            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "contactInfo"]) }
 
             <% if (secondColumnFragments) {
                 secondColumnFragments.each { %>

--- a/omod/src/main/webapp/fragments/summary/section.gsp
+++ b/omod/src/main/webapp/fragments/summary/section.gsp
@@ -2,7 +2,7 @@
     def patient = config.patient
     def appId  = config.appId
 
-    def returnUrl = "/${contextPath}/registrationapp/registrationSummary.page?patientId=${patient.patient.id}"
+    def returnUrl = "/${contextPath}/registrationapp/registrationSummary.page?patientId=${patient.patient.id}&appId=${appId}"
 
 
 %>

--- a/omod/src/main/webapp/pages/registrationSummary.gsp
+++ b/omod/src/main/webapp/pages/registrationSummary.gsp
@@ -17,7 +17,7 @@
         { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
  ,      ${ breadcrumbMiddle },
         { label: "${ ui.escapeJs(ui.format(patient.patient)) }" ,
-            link: '${ui.pageLink("registrationapp", "registrationSummary", [patientId: patient.patient.id])}'}
+            link: '${ui.pageLink("registrationapp", "registrationSummary", [patientId: patient.patient.id, appId: appId])}'}
     ]))
 
     var patient = { id: ${ patient.id } };
@@ -32,4 +32,4 @@
 
 ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient.patient, activeVisit: null, appContextModel: null ]) }
 
-${ ui.includeFragment("registrationapp", "summary/registrationSummary", [patient: patient, appId: "registrationapp.registerPatient"]) }
+${ ui.includeFragment("registrationapp", "summary/registrationSummary", [patient: patient, appId: appId]) }


### PR DESCRIPTION
caused by hard-coded default registration app instead of the appId passed to the page. The default registration app is updated to referenceapplication.registrationapp.registerPatient 