### PR TITLE
RA-1511 Added fix to support the custom fragment info message for editSection

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -49,6 +49,7 @@ registrationapp.clinicalDashboard=Clinical Dashboard
 registrationapp.editPatientContactInfo.label=Edit Patient Contact Info
 registrationapp.editContactInfoMessage.success=Saved changes in contact info for: {0}
 registrationapp.confirm=Confirm submission?
+registrationapp.editCustomSectionInfoMessage.success=Saved changes in {1} for: {0}
 
 registrationapp.birthdate.day.label=Day
 registrationapp.birthdate.month.label=Month

--- a/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/EditSectionPageController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/EditSectionPageController.java
@@ -146,9 +146,15 @@ public class EditSectionPageController {
             try {
                 //The person address changes get saved along as with the call to save patient
                 patientService.savePatient(patient);
-                InfoErrorMessageUtil.flashInfoMessage(request.getSession(),
-                        ui.message("registrationapp.editContactInfoMessage.success", patient.getPersonName() != null ? ui.encodeHtml(patient.getPersonName().toString()) : ""));
-
+                if (sectionId.equals("contactInfo")) {
+                    InfoErrorMessageUtil.flashInfoMessage(request.getSession(),
+                            ui.message("registrationapp.editContactInfoMessage.success", patient.getPersonName() != null ? ui.encodeHtml(patient.getPersonName().toString()) : ""));
+                }
+                else {
+                    String sectionLabel= formStructure.getSections().get(sectionId).getLabel();
+                    InfoErrorMessageUtil.flashInfoMessage(request.getSession(),
+                            ui.message("registrationapp.editCustomSectionInfoMessage.success", patient.getPersonName() != null ? ui.encodeHtml(patient.getPersonName().toString()) : "", sectionLabel));
+                }
                 EventMessage eventMessage = new EventMessage();
                 eventMessage.put(RegistrationCoreConstants.KEY_PATIENT_UUID, patient.getUuid());
                 Event.fireEvent(RegistrationCoreConstants.PATIENT_EDIT_EVENT_TOPIC_NAME, eventMessage);

--- a/omod/src/test/java/org/openmrs/module/registrationapp/page/controller/EditSectionPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/registrationapp/page/controller/EditSectionPageControllerTest.java
@@ -119,7 +119,7 @@ public class EditSectionPageControllerTest {
 		patient.addName(oldName);
 
 		PersonName newName = new PersonName("newGivenName", null, familyName);
-		controller.post(uiSessionContext, null, patient, null, newName, null, null, app, null, null,
+		controller.post(uiSessionContext, null, patient, null, newName, null, null, app, "contactInfo", null,
 				patientService, null,null, request, messageSourceService, null, patientValidator, ui);
 
 		Assert.assertNotSame(oldName, patient.getPersonName());
@@ -145,7 +145,7 @@ public class EditSectionPageControllerTest {
 		
 		//should be case insensitive
 		PersonName newName = new PersonName("givenName", null, "familyName");
-        controller.post(uiSessionContext, null, patient, null, newName, null, null, app, null, null,
+        controller.post(uiSessionContext, null, patient, null, newName, null, null, app, "contactInfo", null,
                 patientService, null, null, request, messageSourceService, null, patientValidator, ui);
 		
 		Assert.assertSame(oldName, patient.getPersonName());
@@ -173,7 +173,7 @@ public class EditSectionPageControllerTest {
         final String newCountry = "Uganda";
         newAddress.setCountry(newCountry);
 
-        controller.post(uiSessionContext, null, patient, newAddress, null, null, null, app, null, null,
+        controller.post(uiSessionContext, null, patient, newAddress, null, null, null, app, "contactInfo", null,
                 patientService, null, null, request, messageSourceService, null, patientValidator, ui);
 
         assertSame(newAddress, patient.getPersonAddress());
@@ -202,7 +202,7 @@ public class EditSectionPageControllerTest {
         PersonAddress newAddress = new PersonAddress();
         newAddress.setCountry(country);
 
-        controller.post(uiSessionContext, null, patient, newAddress, null, null, null, app, null, null,
+        controller.post(uiSessionContext, null, patient, newAddress, null, null, null, app, "contactInfo", null,
                 patientService, null,null, request, messageSourceService, null, patientValidator, ui);
 
         assertSame(address, patient.getPersonAddress());


### PR DESCRIPTION
# Description

- Added fix to support the info message as "Saved changes in _sectionId_ for: _PatientName_", if the sectionId is other than the Contact Info.  
- Added Message property for English.

# Ticket

Ticket Info : https://issues.openmrs.org/browse/RA-1511
