### PR TITLE
RA-1533 Update the registration module to permit editing all sections

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -23,6 +23,7 @@ registrationapp.patient.phone.label=Phone Number
 registrationapp.patient.phone.question=What's the patient phone number?
 
 registrationapp.createdPatientMessage=Created Patient Record: {0}
+registrationapp.updatedPatientMessage=Updated Patient Record: {0}
 
 registrationapp.patient.birthdate.label=Birthdate
 registrationapp.patient.birthdate.question=What's the patient's birth date?

--- a/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
@@ -1,9 +1,7 @@
 package org.openmrs.module.registrationapp.page.controller;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifierType;
-import org.openmrs.RelationshipType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.Extension;
@@ -21,7 +19,6 @@ import org.openmrs.ui.framework.page.PageModel;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Collections;
 
@@ -29,6 +26,7 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
 
     public void get(UiSessionContext sessionContext, PageModel model,
                     @RequestParam("appId") AppDescriptor app,
+                    @RequestParam(value = "patientId", required = false) @BindParams Patient existingPatient,
                     @RequestParam(value = "breadcrumbOverride", required = false) String breadcrumbOverride,
                     @ModelAttribute("patient") @BindParams Patient patient,
                     @SpringBean("emrApiProperties") EmrApiProperties emrApiProperties,
@@ -36,20 +34,24 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
                     UiUtils ui) throws Exception {
 
         sessionContext.requireAuthentication();
-        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, appFrameworkService);
+        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, appFrameworkService, existingPatient);
     }
 
-    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, AppFrameworkService appFrameworkService) throws Exception {
+    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, AppFrameworkService appFrameworkService, Patient existingPatient) throws Exception {
         NavigableFormStructure formStructure = RegisterPatientFormBuilder.buildFormStructure(app);
 
         if (patient == null) {
-        	patient = new Patient();
+          patient = new Patient();
+        } else {
+          patient = existingPatient;
         }
 
         NameSupportCompatibility nameSupport = Context.getRegisteredComponent(NameSupportCompatibility.ID, NameSupportCompatibility.class);
         AddressSupportCompatibility addressSupport = Context.getRegisteredComponent(AddressSupportCompatibility.ID, AddressSupportCompatibility.class);
         
         model.addAttribute("patient", patient);
+        model.addAttribute("patientIdNumber", patient.getId());
+        model.addAttribute("patientUuid", patient.getUuid());
         model.addAttribute("primaryIdentifierType", primaryIdentifierType);
         model.addAttribute("appId", app.getId());
         model.addAttribute("formStructure", formStructure);

--- a/omod/src/main/webapp/pages/registerPatient.gsp
+++ b/omod/src/main/webapp/pages/registerPatient.gsp
@@ -248,6 +248,10 @@ ${ ui.includeFragment("uicommons", "validationMessages")}
                             ])}
                             <!-- we "hide" the unknown flag here since gender is the only field not hidden for an unknown patient -->
                             <input id="demographics-unknown" type="hidden" name="unknown" value="false"/>
+                            <% if (patientIdNumber != null) {%>
+                            	<input id="patientIdNumber" type="hidden" name="patientIdNumber" value="${patientIdNumber}"/>
+                            	<input id="patientUuid" type="hidden" name="patientUuid" value="${patientUuid}"/>
+                            <% } %>
                         </fieldset>
 
                         <fieldset id="demographics-birthdate" class="multiple-input-date date-required no-future-date">

--- a/omod/src/main/webapp/resources/scripts/registerPatient.js
+++ b/omod/src/main/webapp/resources/scripts/registerPatient.js
@@ -17,6 +17,16 @@ function importMpiPatient(id) {
         });
 }
 
+var extractPatientUuid = function(_data) {
+    var variables = _data.split("&");
+    for (var variable of variables) {
+      if (variable.split("=")[0] == "patientUuid") {
+          return variable.split("=")[1];
+      }
+    }
+    return null;
+}
+
 jq(function() {
     NavigatorController = new KeyboardController();
 
@@ -37,8 +47,10 @@ jq(function() {
         return false;
     });
 
-    function showSimilarPatients(data) {
-        if (data.length == 0 || jq('#checkbox-unknown-patient').is(':checked')) {
+    function showSimilarPatients(data, patientUuid) {
+        if (data.length == 0 || jq('#checkbox-unknown-patient').is(':checked')
+         || (data.length == 1 && data[0].uuid == patientUuid)
+        ) {
             jq("#similarPatients").hide();
             jq("#similarPatientsSlideView").hide();
             return;
@@ -118,7 +130,7 @@ jq(function() {
         var url = '/' + OPENMRS_CONTEXT_PATH + '/registrationapp/matchingPatients/getSimilarPatients.action?appId='+appId;
         jq.post(url, formData, function(data) {
             jq("#reviewSimilarPatientsButton").show();
-            showSimilarPatients(data);
+            showSimilarPatients(data, extractPatientUuid(formData));
         }, "json");
 
         focusedField.focus();
@@ -232,7 +244,7 @@ jq(function() {
         var url = '/' + OPENMRS_CONTEXT_PATH + '/registrationapp/matchingPatients/getExactPatients.action?appId='+appId;
         jq.post(url, formData, function(data) {
             jq("#reviewSimilarPatientsButton").hide();
-            showSimilarPatients(data);
+            showSimilarPatients(data, extractPatientUuid(formData));
             jq("#similarPatientsSlideView").show();
         }, "json");
     });

--- a/omod/src/test/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageControllerTest.java
@@ -1,0 +1,163 @@
+package org.openmrs.module.registrationapp.page.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.Relationship;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.PersonService;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.module.appframework.domain.AppDescriptor;
+import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.openmrs.module.appui.UiSessionContext;
+import org.openmrs.module.emrapi.EmrApiProperties;
+import org.openmrs.module.registrationapp.AddressSupportCompatibility;
+import org.openmrs.module.registrationapp.NameSupportCompatibility;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.page.PageModel;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Context.class})
+public class RegisterPatientPageControllerTest {
+    @Mock
+    private UiSessionContext uiSessionContext;
+    
+    @Mock
+    private PersonService personService;
+    
+    @Mock
+    private AppDescriptor app;
+
+    @Mock
+    private UiUtils ui;
+
+    @Mock
+    AppFrameworkService appFrameworkService;
+
+    @Mock
+    EmrApiProperties emrApiProperties;
+
+    @Mock
+    NameSupportCompatibility nameSupportCompatibility;
+
+    @Mock
+    AddressSupportCompatibility addressSupport;
+
+    @Mock
+    JsonNode jsonNode;
+
+    @Mock
+    AdministrationService administrationService;
+
+    private RegisterPatientPageController registerPatientPageController;
+    
+    PageModel pageModel;
+    PatientIdentifierType patientIdentifierType;
+    String breadcrumbOverride;
+
+    @Before
+    public void setUpMockUserContext() throws Exception {
+        PowerMockito.mockStatic(Context.class);
+        Mockito.when(nameSupportCompatibility.getDefaultLayoutTemplate()).thenReturn(new Object());
+        Mockito.when(Context.getRegisteredComponent(NameSupportCompatibility.ID, NameSupportCompatibility.class)).thenReturn(nameSupportCompatibility);
+        Mockito.when(administrationService.getGlobalProperty("addresshierarchy.enableOverrideOfAddressPortlet", "false")).thenReturn("value");
+        Mockito.when(Context.getAdministrationService()).thenReturn(administrationService);
+        Mockito.when(personService.getAllRelationships()).thenReturn(new ArrayList<Relationship>());
+        Mockito.when(Context.getPersonService()).thenReturn(personService);
+
+        Mockito.when(addressSupport.getDefaultLayoutTemplate()).thenReturn(new Object());
+        Mockito.when(Context.getRegisteredComponent(AddressSupportCompatibility.ID, AddressSupportCompatibility.class)).thenReturn(addressSupport);
+
+        UserContext userContext = Mockito.mock(UserContext.class);
+        Context.setUserContext(userContext);
+        Mockito.when(userContext.isAuthenticated()).thenReturn(true);
+
+        pageModel = new PageModel();
+
+        ObjectNode objectNode = new ObjectNode(null);
+        objectNode.put("sections", new ArrayNode(null));
+        Mockito.when(jsonNode.isNull()).thenReturn(false);
+        Mockito.when(jsonNode.getBooleanValue()).thenReturn(true);
+        objectNode.put("registrationEncounter", jsonNode);
+        objectNode.put("allowRetrospectiveEntry", jsonNode);
+        objectNode.put("allowUnknownPatients", jsonNode);
+        objectNode.put("allowManualIdentifier", jsonNode);
+        objectNode.put("patientDashboardLink", jsonNode);
+        Mockito.when(app.getConfig()).thenReturn(objectNode);
+
+        Mockito.when(emrApiProperties.getPrimaryIdentifierType()).thenReturn(patientIdentifierType);
+
+        patientIdentifierType = new PatientIdentifierType();
+        patientIdentifierType.setId(1);
+
+        breadcrumbOverride = "home>sample";
+
+        List<Extension> extensions = new ArrayList<Extension>();
+        extensions.add(new Extension());
+        Mockito.when(appFrameworkService.getExtensionsForCurrentUser("registerPatient.includeFragments")).thenReturn(extensions);
+
+        registerPatientPageController = new RegisterPatientPageController();
+    }
+
+    @Test
+    public void get_shouldCreateANewPatientWhenPatientIsNull() throws Exception {
+        // Fixture setup
+        Patient existingPatient = null;
+
+        // Execution
+        registerPatientPageController.get(
+                uiSessionContext,
+                pageModel,
+                app,
+                existingPatient,
+                breadcrumbOverride,
+                existingPatient,
+                emrApiProperties,
+                appFrameworkService,
+                ui);
+
+        // Assertion
+        Patient result = (Patient) pageModel.getAttribute("patient");
+        Assert.assertNotNull(result);
+        Assert.assertNull(result.getId());
+    }
+
+    @Test
+    public void get_shouldUseExistingPatientWhenPatientIsNotNull() throws Exception {
+        // Fixture setup
+        Patient existingPatient = new Patient();
+        existingPatient.setId(10);
+
+        // Execution
+        registerPatientPageController.get(
+                uiSessionContext,
+                pageModel,
+                app,
+                existingPatient,
+                breadcrumbOverride,
+                existingPatient,
+                emrApiProperties,
+                appFrameworkService,
+                ui);
+
+        // Assertion
+        Patient result = (Patient) pageModel.getAttribute("patient");
+        Assert.assertEquals(existingPatient.getId(), result.getId());
+    }
+}


### PR DESCRIPTION
This PR updates RegisterPatientFragmentController, and adds a new method that handles the edit of the entire patient registration form (without modifying the existing code that handles adding a new registration). When an extra query parameter (patientIdNumber) is included, the controller edits the existing patient. This solution is backward compatible: it doesn't alter the current patient registration flow and adds the possibility to also edit a patient