### PR TITLE
Support Coded Person Attributes in Reference Application Registration

### DIFF
--- a/omod/src/main/webapp/fragments/field/codedPersonAttributes.gsp
+++ b/omod/src/main/webapp/fragments/field/codedPersonAttributes.gsp
@@ -1,0 +1,10 @@
+<p>
+  <select name="" size="6">
+    <option value ="LFHC:901">Lao</option>
+    <option value ="LFHC:902">Hmong</option>
+    <option value ="LFHC:905">Khmuic</option>
+    <option value ="LFHC:906">Other Lao</option>
+    <option value ="LFHC:911">Foreigner</option>
+  </select>
+  <span class="field-error"></span>
+</p>


### PR DESCRIPTION
For this https://issues.openmrs.org/browse/RA-982 ,i have added  a fragment named codedPersonAttributes containing code for  a coded person attribute within a dropDown.And this fragment can be added to the UI by calling its name and module within a json file as described here https://wiki.openmrs.org/display/docs/Registration+App+Configuration#RegistrationAppConfiguration-AddPersonAttributes