### PR TITLE
RA-1630:Display Concept Names on Patient Registration Summary instead of Concept IDs

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/RegistrationAppUiUtils.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/RegistrationAppUiUtils.java
@@ -61,7 +61,23 @@ public class RegistrationAppUiUtils {
 		
 		return null;
 	}
-	
+	/**
+	 * @since 1.15.0
+	 * Gets the person attribute display value for the specified person attribute type uuid
+	 * @return the person attribute display value
+	 */
+	public String getPersonAttributeDisplayValue(Person person, String attributeTypeUuid) {
+		if (person != null) {
+			PersonAttribute attr = person.getAttribute(Context.getPersonService().getPersonAttributeTypeByUuid(
+					attributeTypeUuid));
+			if (attr != null) {
+				return attr.toString();
+			}
+		}
+
+		return null;
+	}
+
 	/**
 	 * Gets the patient identifier value for the specified person for the identifierTypeUuid
 	 * that matches the specified uuid

--- a/omod/src/main/webapp/fragments/summary/section.gsp
+++ b/omod/src/main/webapp/fragments/summary/section.gsp
@@ -63,7 +63,7 @@
                     <% fields.each { field ->
                         def displayValue = "";
                         if (field.type == 'personAttribute') {
-                            displayValue = uiUtils.getAttribute(patient.patient, field.uuid)?.replace("\n", "<br />");
+                            displayValue = uiUtils.getPersonAttributeDisplayValue(patient.patient, field.uuid)?.replace("\n", "<br />");
                         }
                         else if (field.type == 'personAddress') {
                             displayValue = ui.format(config.patient.personAddress).replace("\n", "<br />");


### PR DESCRIPTION
For the ticket https://issues.openmrs.org/browse/RA-1630, i have use the method toString instead of getAttribute to display the Concept Name