### PR TITLE
RA-1765 - Registration Summary should use bootstrap styling

### DIFF
--- a/omod/src/main/webapp/fragments/summary/registrationSummary.gsp
+++ b/omod/src/main/webapp/fragments/summary/registrationSummary.gsp
@@ -1,60 +1,61 @@
 <%
     def returnUrl = "/${contextPath}/registrationapp/registrationSummary.page?patientId=${patient.patient.id}&appId=${appId}"
-
 %>
 
-
 <div class="clear"></div>
-<div class="dashboard clear">
-        <div class="info-container column">
-            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "demographics"]) }
+<div class="dashboard clear row">
+    <div class="col-12 col-lg-9">
+        <div class="row">
+            <div class="col-12 col-lg-6">
 
-            <% if (firstColumnFragments) {
-                firstColumnFragments.each {
-                    // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
-                    def configs = [:];
-                    if(it.extensionParams.fragmentConfig != null){
-                        configs = it.extensionParams.fragmentConfig;
-                    }
-                    configs << [patient: patient, patientId: patient.patient.id, app: it.appId, appId: appId, returnUrl: returnUrl ]
-            %>
-                    ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, configs)}
-            <% }
-            } %>
-        </div>
+                ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "demographics"]) }
 
-        <div class="info-container column">
-            ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "contactInfo"]) }
+                <% if (firstColumnFragments) {
+                    firstColumnFragments.each {
+                        // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
+                        def configs = [:];
+                        if(it.extensionParams.fragmentConfig != null){
+                            configs = it.extensionParams.fragmentConfig;
+                        }
+                        configs << [patient: patient, patientId: patient.patient.id, app: it.appId, appId: appId, returnUrl: returnUrl ]
+                %>
+                        ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, configs)}
+                <% }
+                } %>
 
-            <% if (secondColumnFragments) {
-                secondColumnFragments.each {
-                    // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
-                    def configs = [:];
-                    if(it.extensionParams.fragmentConfig != null){
-                        configs = it.extensionParams.fragmentConfig;
-                    }
-                    configs << [patient: patient, patientId: patient.patient.id, app: it.appId, appId: appId, returnUrl: returnUrl ]
-            %>
-                    ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, configs)}
-            <% }
-            } %>
+            </div>
+            <div class="col-12 col-lg-6">
+                ${ ui.includeFragment("registrationapp", "summary/section", [patient: patient, appId: appId, sectionId: "contactInfo"]) }
 
-        </div>
-
-        <div class="action-container column">
-            <div class="action-section">
-                <ul>
-                    <h3>${ ui.message("coreapps.clinicianfacing.overallActions") }</h3>
-                    <%
-                        overallActions.each { ext -> %>
-                            <a href="${ ui.escapeJs(ext.url("/" + ui.contextPath(), appContextModel, returnUrl)) }" id="${ ext.id }">
-                                <li>
-                                    <i class="${ ext.icon }"></i>
-                                    ${ ui.message(ext.label) }
-                                </li>
-                            </a>
-                    <% } %>
-                </ul>
+                <% if (secondColumnFragments) {
+                    secondColumnFragments.each {
+                        // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
+                        def configs = [:];
+                        if(it.extensionParams.fragmentConfig != null){
+                            configs = it.extensionParams.fragmentConfig;
+                        }
+                        configs << [patient: patient, patientId: patient.patient.id, app: it.appId, appId: appId, returnUrl: returnUrl ]
+                %>
+                        ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, configs)}
+                <% }
+                } %>
             </div>
         </div>
     </div>
+    <div class="col-12 order-first col-lg-3 order-lg-last p-0">
+        <div class="action-section">
+            <ul>
+                <h3>${ ui.message("coreapps.clinicianfacing.overallActions") }</h3>
+                <%
+                    overallActions.each { ext -> %>
+                        <a href="${ ui.escapeJs(ext.url("/" + ui.contextPath(), appContextModel, returnUrl)) }" id="${ ext.id }">
+                            <li>
+                                <i class="${ ext.icon }"></i>
+                                ${ ui.message(ext.label) }
+                            </li>
+                        </a>
+                <% } %>
+            </ul>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This adds bootstrap styling consistent with the coreapps clinical facing dashboard.  It moves the action menu to the top (see RA-1764) and moves from a 2/3 column layout to a one column layout for easy scrolling and viewing.  Screenshots showing before and after of laptop and emulated mobile view below:

**Registration Summary on Laptop (Before and After)**

![registration-summary-before](https://user-images.githubusercontent.com/356297/82942109-70ba6b00-9f65-11ea-9a60-9284683e5228.png)

![registration-summary-after](https://user-images.githubusercontent.com/356297/82942114-73b55b80-9f65-11ea-8be5-d13542c0ebc9.png)

**Registration Summary on emulated tablet (Before and After)**

![registration-summary-before-mobile](https://user-images.githubusercontent.com/356297/82942183-947db100-9f65-11ea-8a1b-c643730eb72f.png)

![registration-summary-after-mobile](https://user-images.githubusercontent.com/356297/82942188-9778a180-9f65-11ea-8689-86c1cab7109b.png)
