### PR TITLE
RA-1717:Confirm button is not enabled when editing Relationships

### DIFF
--- a/omod/src/main/webapp/pages/editSection.gsp
+++ b/omod/src/main/webapp/pages/editSection.gsp
@@ -220,10 +220,11 @@ ${ ui.includeFragment("uicommons", "validationMessages")}
             <div class="before-dataCanvas"></div>
             <div id="dataCanvas"></div>
             <div class="after-data-canvas"></div>
-            <div id="confirmationQuestion">
+            <div id="confirmationQuestion" class="focused"> confirm submission?
                 ${ui.message("registrationapp.confirm")}
                 <p style="display: inline">
-                    <button id="registration-submit" type="submit" class="submitButton confirm right">
+                    <button id="registration-submit" class="confirm" type=submit value="">
+                      Confirm
                         ${ui.message("registrationapp.patient.confirm.label")}
                     </button>
                 </p>

--- a/omod/src/main/webapp/resources/scripts/field/personRelationship.js
+++ b/omod/src/main/webapp/resources/scripts/field/personRelationship.js
@@ -73,5 +73,14 @@ angular.module('personRelationships', ['personService', 'relationshipService', '
                     return r.name +  " - " + jq('.rel_type:first').children("[value='" + r.type + "']").text();
                 }).join(', ');
             }
+
+           // second hack: when editing relationships, enable the Confirm button
+           if (NavigatorController.getSection().length === 2) {
+               if ($scope.relationships[0].name) {
+                   NavigatorController.getField("registration-submit").enable();
+               } else {
+                   NavigatorController.getField("registration-submit").disable();
+               }
+            }
         }
     }]);


### PR DESCRIPTION
**Description of what I did:**
I enabled the confirm button on relationship edit page which was inactive initially.

**Link to the issue worked on:** 
https://issues.openmrs.org/browse/RA-1717