### PR TITLE
RA-1717:Cannot save relationship edits: confirm button is not enabled when editing relationships

### DIFF
--- a/omod/src/main/webapp/pages/editSection.gsp
+++ b/omod/src/main/webapp/pages/editSection.gsp
@@ -219,8 +219,6 @@ ${ ui.includeFragment("uicommons", "validationMessages")}
             <span class="title">${ui.message("registrationapp.patient.confirm.label")}</span>
             <div class="before-dataCanvas"></div>
             <div id="dataCanvas"></div>
-            <div class="after-data-canvas"></div>
-            <div id="confirmationQuestion">
                 ${ui.message("registrationapp.confirm")}
                 <p style="display: inline">
                     <button id="registration-submit" type="submit" class="submitButton confirm right">
@@ -232,6 +230,5 @@ ${ ui.includeFragment("uicommons", "validationMessages")}
                         ${ui.message("registrationapp.cancel")}
                     </button>
                 </p>
-            </div>
         </div>
     </form>


### PR DESCRIPTION
Description of what I did:

I removed 
```
<div class="after-data-canvas"></div>
<div id="confirmationQuestion">
```
on line 222 and 223 to enable the confirm button when editing relationship section.

Issue worked on"
https://issues.openmrs.org/browse/RA-1717

![Uploading Capture2.PNG…](https://imgur.com/a/jzOSMXm)



