### PR TITLE
RA-1717:Cannot save relationship edits: confirm button is not enabled when editing relationships

### DIFF
--- a/omod/src/main/webapp/resources/scripts/field/personRelationship.js
+++ b/omod/src/main/webapp/resources/scripts/field/personRelationship.js
@@ -74,4 +74,9 @@ angular.module('personRelationships', ['personService', 'relationshipService', '
                 }).join(', ');
             }
         }
+        field.value = function() {
+            return $scope.relationships.map(function(r) {
+                return r.name +  " - " + jq('.rel_type:first').children("[value='" + r.type + "']").text();
+            }).join(', ');
+        }
     }]);


### PR DESCRIPTION
Issue worked on:
https://issues.openmrs.org/browse/RA-1717

Description of what changed:
I overrode the  displayValue() function in the personRelationship controller to enable confirm button when editing relationships.