### PR TITLE
RA-1898  Reigstration app using old `emr.` message codes - pt 1 - emr.gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Registration App Module
 ========================
 
 Registration App for the Reference Application
+
+Documentation is in the [wiki](https://wiki.openmrs.org/display/docs/Registration+Module).

--- a/omod/src/main/webapp/fragments/summary/section.gsp
+++ b/omod/src/main/webapp/fragments/summary/section.gsp
@@ -51,7 +51,7 @@
             <% } %>
 
             <div>
-                <h3>${ ui.message("emr.gender") }:</h3>
+                <h3>${ ui.message("Patient.gender") }:</h3>
                 <p class="left">
                     ${ui.message("coreapps.gender." + ui.encodeHtml(patient.gender))}&nbsp;
                 </p>

--- a/omod/src/main/webapp/pages/editSection.gsp
+++ b/omod/src/main/webapp/pages/editSection.gsp
@@ -14,7 +14,7 @@
     def localizedGenderOptions = []
 
     genderOptions.each { optn ->
-    	localizedGenderOptions << [label: ui.message("emr.gender." + optn), value: optn]
+    	localizedGenderOptions << [label: ui.message("coreapps.gender." + optn), value: optn]
     }
 
     def monthOptions = [ [label: ui.message("registrationapp.month.1"), value: 1],
@@ -144,7 +144,7 @@ ${ ui.includeFragment("uicommons", "validationMessages")}
                 </fieldset>
 
                 <fieldset id="demographics-gender">
-                    <legend id="genderLabel">${ ui.message("emr.gender") }</legend>
+                    <legend id="genderLabel">${ ui.message("Patient.gender") }</legend>
                     ${ ui.includeFragment("uicommons", "field/dropDown", [
                             label: ui.message("registrationapp.patient.gender.question"),
                             emptyOptionLabel: "uicommons.select",

--- a/omod/src/main/webapp/pages/registerPatient.gsp
+++ b/omod/src/main/webapp/pages/registerPatient.gsp
@@ -21,8 +21,8 @@
     def genderCodes = []
 
     genderOptions.each { optn ->
-    	localizedGenderOptions << [label: ui.message("emr.gender." + optn), value: optn]
-    	genderCodes << 'emr.gender.' + optn
+    	localizedGenderOptions << [label: ui.message("coreapps.gender." + optn), value: optn]
+    	genderCodes << 'coreapps.gender.' + optn
     }
 
     Calendar cal = Calendar.getInstance()
@@ -280,7 +280,7 @@ fieldset[id\$="-fieldset"] div > div {
 
                         <${combineSubSections == true ? "div" : "fieldset"} id="demographics-gender">
 
-                            ${combineSubSections == true ? "" : "<legend id=\"genderLabel\">" + ui.message("emr.gender") + "</legend>"}
+                            ${combineSubSections == true ? "" : "<legend id=\"genderLabel\">" + ui.message("Patient.gender") + "</legend>"}
 
                             ${ ui.includeFragment("uicommons", "field/dropDown", [
                                     id: "gender",

--- a/omod/src/main/webapp/resources/scripts/registerPatient.js
+++ b/omod/src/main/webapp/resources/scripts/registerPatient.js
@@ -61,7 +61,7 @@ jq(function() {
 
             cloned.find('.name').append(item.givenName + ' ' + item.familyName);
 
-            var gender = emr.message('emr.gender.' + item.gender);
+            var gender = emr.message('coreapps.gender.' + item.gender);
 
             var attributes = "";
             if (item.attributeMap) {
@@ -162,7 +162,7 @@ jq(function() {
 
             cloned.find('.name').append(item.givenName + ' ' + item.familyName);
 
-            var gender = emr.message('emr.gender.' + item.gender);
+            var gender = emr.message('coreapps.gender.' + item.gender);
 
             var attributes = "";
             if (item.attributeMap) {


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-1898

This just gets rid of the `emr.gender` codes. Eliminating other `emr.` codes are still TODO.

![Screenshot from 2021-03-02 11-31-16](https://user-images.githubusercontent.com/1031876/109710210-3dd78000-7b52-11eb-83ff-fb7f4945e3a6.png)
