### PR TITLE
RA-1898 Change all 'emr.' message codes to 'coreapps.' equivalents

### DIFF
--- a/api/src/test/java/org/openmrs/module/registrationapp/model/SectionTest.java
+++ b/api/src/test/java/org/openmrs/module/registrationapp/model/SectionTest.java
@@ -16,10 +16,10 @@ public class SectionTest {
     public void testParsing() throws Exception {
         Section parsed = new ObjectMapper().readValue(getClass().getClassLoader().getResourceAsStream("section.json"), Section.class);
         assertThat(parsed.getId(), is("contactInfo"));
-        assertThat(parsed.getLabel(), is("emr.patientDashBoard.contactinfo"));
+        assertThat(parsed.getLabel(), is("coreapps.patientDashBoard.contactinfo"));
         assertTrue(parsed.getSkipConfirmation());
         assertThat(parsed.getQuestions().size(), is(1));
-        assertThat(parsed.getQuestions().get(0).getLegend(), is("emr.person.telephoneNumber"));
+        assertThat(parsed.getQuestions().get(0).getLegend(), is("coreapps.person.telephoneNumber"));
         assertThat(parsed.getQuestions().get(0).getFields().size(), is(1));
         assertThat(parsed.getQuestions().get(0).getFields().get(0).getType(), is("personAttribute"));
         assertThat(parsed.getQuestions().get(0).getFields().get(0).getLabel(), is("registrationapp.patient.phone.label"));

--- a/api/src/test/resources/registrationAppConfig.json
+++ b/api/src/test/resources/registrationAppConfig.json
@@ -14,7 +14,7 @@
     "sections": [
         {
             "id": "contactInfo",
-            "label": "emr.patientDashBoard.contactinfo"
+            "label": "coreapps.patientDashBoard.contactinfo"
         }
     ]
 }

--- a/api/src/test/resources/section.json
+++ b/api/src/test/resources/section.json
@@ -1,10 +1,10 @@
 {
     "id": "contactInfo",
-    "label": "emr.patientDashBoard.contactinfo",
+    "label": "coreapps.patientDashBoard.contactinfo",
     "skipConfirmation": true,
     "questions": [
         {
-            "legend": "emr.person.telephoneNumber",
+            "legend": "coreapps.person.telephoneNumber",
             "fields": [
                 {
                     "type": "personAttribute",

--- a/omod/src/main/webapp/fragments/field/personName.gsp
+++ b/omod/src/main/webapp/fragments/field/personName.gsp
@@ -13,7 +13,7 @@
 <p <% if (config.left) { %> class="left" <% } %> >
 
     <label for="${ config.id }-field">
-        ${ config.label } <% if (config.classes && config.classes.contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
+        ${ config.label } <% if (config.classes && config.classes.contains("required")) { %><span>(${ ui.message("coreapps.formValidation.messages.requiredField.label") })</span><% } %>
     </label>
 
     <input type="text" id="${ config.id }-field" name="${ config.formFieldName }" value="${ config.initialValue ?: '' }"
@@ -21,7 +21,7 @@
 
     ${ ui.includeFragment("uicommons", "fieldErrors", [ fieldName: config.formFieldName ]) }
     <% if (config.optional) { %>
-    ${ ui.message("emr.optional") }
+    ${ ui.message("coreapps.optional") }
     <% } %>
 </p>
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-1898

See [coreapps message.properties](https://github.com/openmrs/openmrs-module-coreapps/blob/master/api/src/main/resources/messages.properties) for reference.

This was previously showing "required" where it now says "necesario"

![Screenshot from 2021-03-03 08-36-30](https://user-images.githubusercontent.com/1031876/109839963-7895f280-7bfc-11eb-88a6-0d4e54b36a18.png)
