### PR TITLE
RA-1806:Double Brace Initialization should not be used

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/summary/RegistrationSummaryFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/summary/RegistrationSummaryFragmentController.java
@@ -85,7 +85,8 @@ public class RegistrationSummaryFragmentController {
      */
     protected List<Extension> filter(final List<Extension> extensionList, final String extensionPointId) {
     	
-    	List<Extension> ret = new ArrayList<Extension>() {{ addAll(extensionList); }};
+    	List<Extension> ret = new ArrayList<Extension>();
+    	ret.addAll(extensionList);
     	
     	CollectionUtils.filter(ret, new Predicate<Extension>() {
     		@Override


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-1806

The ticket required me to replace List ret = new ArrayList() {{ addAll(extensionList); }};

with this:

List ret = new ArrayList();
ret.addAll(extensionList);

which I have done.

The reason for the change is described below:

Because Double Brace Initialization (DBI) creates an anonymous class with a reference to the instance of the owning object, its use can lead to memory leaks if the anonymous inner class is returned and held by other objects. Even when there's no leak, DBI is so obscure that it's bound to confuse most maintainers.



