### PR TITLE
RA-1812 Change comparison method of string of objects to equals()

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/RegistrationAppUiUtils.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/RegistrationAppUiUtils.java
@@ -95,7 +95,7 @@ public class RegistrationAppUiUtils {
 		if (person != null) {
 			List<Relationship> relationships = Context.getPersonService().getRelationshipsByPerson(person);
 			for (Relationship relationship : relationships) {
-				if(relationship.getPersonA().getUuid() != person.getUuid()){
+				if(!relationship.getPersonA().getUuid().equals(person.getUuid())){
 					rels.append(relationship.getPersonA().getPersonName()).append(" - ").append(ui.message(relationship.getRelationshipType().getaIsToB()));
                 } else {
                 	rels.append(relationship.getPersonB().getPersonName()).append(" - ").append(ui.message(relationship.getRelationshipType().getbIsToA()));


### PR DESCRIPTION
### Issue
[[RA-1812] Comparison of String objects using == or !=](https://issues.openmrs.org/browse/RA-1812)

### Approach 
Used the built-in search tool in IntelliJ to find string comparisons and changed the found one from `!=` to `!string1.equals(string2)`

### Comments
While searching for `Java` string comparisons I found that in some `Javascript` files they have only used `==` where using a `===` comparison is necessary. 
