### PR TITLE
RA-1922 - Fixed patient comparison when searching for similar patients

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/MatchingPatientsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/MatchingPatientsFragmentController.java
@@ -178,7 +178,7 @@ public class MatchingPatientsFragmentController {
 
     private Boolean alreadyInResults(Patient patient, List<SimpleObject> results) {
         for (SimpleObject result : results) {
-            if (result.get("uuid").toString().equals(patient.getId())) {
+            if (result.get("uuid").toString().equals(patient.getUuid())) {
                 return true;
             }
         }

--- a/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/MatchingPatientsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/MatchingPatientsFragmentController.java
@@ -178,7 +178,7 @@ public class MatchingPatientsFragmentController {
 
     private Boolean alreadyInResults(Patient patient, List<SimpleObject> results) {
         for (SimpleObject result : results) {
-            if (Integer.valueOf(result.get("patientId").toString()).equals(patient.getId())) {
+            if (result.get("uuid").toString().equals(patient.getId())) {
                 return true;
             }
         }


### PR DESCRIPTION
**Ticket:** [RA-1922](https://issues.openmrs.org/browse/RA-1922)

**Description:**
When searching for similar patients, there's a list of SimpleObjects with the results. This list is iterated and compared using the patietId. The issue is that the result has no patientId, causing a null pointer ex.
Fixed to comparison to rely on uuid instead.