### PR TITLE
Changing rubygems link to work with later Maven versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
 		</repository>
 		<repository>
 	        <id>rubygems-releases</id>
-	        <url>http://rubygems-proxy.torquebox.org/releases</url>
+	        <url>https://rubygems-proxy.torquebox.org/releases/url</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Changed the RubyGems link from _http://rubygems-proxy.torquebox.org/releases_ to _https://rubygems-proxy.torquebox.org/releases/url_ in order for it to work with recent Maven versions. 