### PR TITLE
RA-2020: Fix auto update of translations from transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,25 +1,9 @@
 [main]
 host = https://www.transifex.com/
 
-[OpenMRS.registrationapp-module]
+[o:openmrs:p:OpenMRS:r:registrationapp-module]
 source_file = api/src/main/resources/messages.properties
 source_lang = en
-trans.ar = api/src/main/resources/messages_ar.properties
-trans.de = api/src/main/resources/messages_de.properties
-trans.el = api/src/main/resources/messages_el.properties
-trans.es = api/src/main/resources/messages_es.properties
-trans.fa = api/src/main/resources/messages_fa.properties
-trans.fr = api/src/main/resources/messages_fr.properties
-trans.hi = api/src/main/resources/messages_hi.properties
-trans.ht = api/src/main/resources/messages_ht.properties
-trans.hy = api/src/main/resources/messages_hy.properties
-trans.id_ID = api/src/main/resources/messages_id_ID.properties
-trans.it = api/src/main/resources/messages_it.properties
-trans.ku = api/src/main/resources/messages_ku.properties
-trans.lt = api/src/main/resources/messages_lt.properties
-trans.pl = api/src/main/resources/messages_pl.properties
-trans.pt = api/src/main/resources/messages_pt.properties
-trans.ru = api/src/main/resources/messages_ru.properties
-trans.si = api/src/main/resources/messages_si.properties
-trans.sw = api/src/main/resources/messages_sw.properties
-trans.te = api/src/main/resources/messages_te.properties
+file_filter = api/src/main/resources/messages_<lang>.properties
+type = UNICODEPROPERTIES 
+


### PR DESCRIPTION
**Description**
Updated my transifex client.
Running tx migrate created a back up for previous config.
Runningtx pull --all -f I was able to pull down all message property translation files and have them update the source on my machine. The -f flag ensured that my machine was updated from the server, even if the files were newer. I then committed these changes back to the repo.

**Related Issue**
see https://issues.openmrs.org/browse/RA-2020