### PR TITLE
UHM-7478, disable address hierarchy levels if there are no entries in the db

### DIFF
--- a/omod/src/main/webapp/fragments/field/personAddressWithHierarchy.gsp
+++ b/omod/src/main/webapp/fragments/field/personAddressWithHierarchy.gsp
@@ -1,5 +1,6 @@
 <%
     ui.includeJavascript("registrationapp", "field/personAddressWithHierarchy.js")
+    ui.includeCss("registrationapp","registerPatient.css")
 
     def parseAsBoolean = {
         if (it instanceof org.codehaus.jackson.node.BooleanNode) {

--- a/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
+++ b/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
@@ -74,6 +74,9 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
                 } else if (result.length == 1) {
                     setValue(level.addressField, result[0].name);
                     preloadLevels(levelAfter(level.addressField));
+                } else {
+                    // focus on the element
+                    getInputElementFor(level.addressField).focus();
                 }
             });
         }
@@ -191,15 +194,18 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
         return null;
     }
 
+    function enableAddressField(level) {
+        let inputElement = getInputElementFor(level.addressField);
+        if (inputElement) {
+            // reset any elements that might have been disabled when selecting a level with no descendants
+            inputElement.removeAttr('disabled');
+            inputElement.removeClass("disabled");
+            inputElement.triggerHandler("enable", this);
+        }
+    }
     function clearLevelsAfter(addressField) {
         _.each(levelsAfter(addressField), function (level) {
-            let inputElement = getInputElementFor(level.addressField);
-            if (inputElement) {
-                // reset any elements that might have been disabled when selecting a level with no descendants
-                inputElement.removeAttr('disabled');
-                inputElement.removeClass("disabled");
-                inputElement.triggerHandler("enable", this);
-            }
+            enableAddressField(level);
             setValue(level.addressField, '');
         });
     }
@@ -251,7 +257,7 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
                     var level = levelFor(addressField);
                     if (ui.item.value != level.lastSelection) {
                         clearLevelsAfter(addressField);
-                        //setValue(level.addressField, ui.item.value);
+                        setValue(level.addressField, ui.item.value);
                         preloadLevels(levelAfter(level.addressField));
                     }
                     level.lastSelection = ui.item.value;
@@ -268,10 +274,6 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
                     setTimeout(function () {
                         element.focus();
                     });
-                }
-                // There is no 'select' event when you clear the autocomplete, so handle that scenario here
-                if (element.val() == '') {
-                    //clearLevelsAfter(addressField);
                 }
             }).focus(function () {
                 $(this).select(); // selecting the entire field on focus makes this feel more like an autocomplete
@@ -303,6 +305,7 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
         select: function (event, ui) {
             // first, clear everything else
             _.each(levels, function (item) {
+                enableAddressField(item);
                 setValue(item.addressField, '');
             });
             _.each(ui.item.data, function (value, key) {

--- a/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
+++ b/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
@@ -45,10 +45,9 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
         if (!_.contains(personAddressWithHierarchy.manualFields, level.addressField)) {
             let inputElement = getInputElementFor(level.addressField);
             if (inputElement) {
-                // if this is not a manual field, then disable it
-                inputElement._removeClass('required');
-                inputElement._addClass('disabled');
-                inputElement.attr('disabled', true);
+                inputElement.attr('disabled', 'true');
+                inputElement.addClass("disabled");
+                inputElement.triggerHandler("disable", this);
             }
         }
         let nextLevel = levelAfter(level.addressField);
@@ -197,8 +196,9 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
             let inputElement = getInputElementFor(level.addressField);
             if (inputElement) {
                 // reset any elements that might have been disabled when selecting a level with no descendants
-                inputElement._removeClass('disabled');
-                inputElement.attr('disabled', false);
+                inputElement.removeAttr('disabled');
+                inputElement.removeClass("disabled");
+                inputElement.triggerHandler("enable", this);
             }
             setValue(level.addressField, '');
         });
@@ -251,7 +251,7 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
                     var level = levelFor(addressField);
                     if (ui.item.value != level.lastSelection) {
                         clearLevelsAfter(addressField);
-                        setValue(level.addressField, ui.item.value);
+                        //setValue(level.addressField, ui.item.value);
                         preloadLevels(levelAfter(level.addressField));
                     }
                     level.lastSelection = ui.item.value;
@@ -271,7 +271,7 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
                 }
                 // There is no 'select' event when you clear the autocomplete, so handle that scenario here
                 if (element.val() == '') {
-                    clearLevelsAfter(addressField);
+                    //clearLevelsAfter(addressField);
                 }
             }).focus(function () {
                 $(this).select(); // selecting the entire field on focus makes this feel more like an autocomplete

--- a/omod/src/main/webapp/resources/styles/registerPatient.scss
+++ b/omod/src/main/webapp/resources/styles/registerPatient.scss
@@ -3,7 +3,9 @@
   width: 1000px !important;
 }
 
-
+.disabled {
+  background-color: #CCCCCC;
+}
 .icon-ok{
   width: 19px !important;
 }


### PR DESCRIPTION
Hi @mogoodrich , here is my attempt to implement the change we discussed with @mseaton yesterday. This is not complete, I still have a couple corner cases to cover, but just wanted to make sure I am going into the right direction. I think you were the original author of this code, so I you probably have a better sense if this PR is in the accordance with the rest of the code in this widget. Thanks!
Here is screenshot of the address form when selecting a country with no address hierarchy levels:

<img width="932" alt="Screenshot 2023-10-06 at 8 11 21 AM" src="https://github.com/openmrs/openmrs-module-registrationapp/assets/1633285/1bec28dc-45e3-4101-ba7c-7506b4008919">

