### PR TITLE
UHM-7476, prevent the user from typing in invalid person names

### DIFF
--- a/api/src/main/java/org/openmrs/module/registrationapp/model/RegisterPersonRelationshipWidget.java
+++ b/api/src/main/java/org/openmrs/module/registrationapp/model/RegisterPersonRelationshipWidget.java
@@ -24,6 +24,8 @@ public class RegisterPersonRelationshipWidget extends Widget {
     public static class Config {
 
         @JsonProperty
+        private String id;
+        @JsonProperty
         private String relationshipType;
 
         @JsonProperty
@@ -41,6 +43,13 @@ public class RegisterPersonRelationshipWidget extends Widget {
         public Config() {
         }
 
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
 
         public String getRelationshipType() {
             return relationshipType;

--- a/omod/src/main/webapp/resources/scripts/field/registerPersonRelationship.js
+++ b/omod/src/main/webapp/resources/scripts/field/registerPersonRelationship.js
@@ -2,6 +2,28 @@ function RegisterPatientRelationship(patientRelationship) {
 
   let selectedPersons = [];
 
+  var relationshipExitHandler = {
+    handleExit: function(field) {
+                  let fieldId = patientRelationship.id + "-field";
+                  let element = getInputElementFor(fieldId);
+                  // clear any previous errors
+                  $(element).next(".field-error").remove();
+                  if (!field.value()) {
+                    return true;
+                  } else {
+                    let selectedVal = getValue(patientRelationship.id + "-relationship_type");
+                    if ( !selectedVal ) {
+                      // no person from the search results list was selected
+                      $('<span class="field-error" style="">Invalid entry</span>').insertAfter('#' + fieldId);
+                      return false;
+                    } else {
+                      return true;
+                    }
+                  }
+                  return false;
+                }
+  }
+  ExitHandlers['relationships-' + patientRelationship.id] = relationshipExitHandler;
   //returns Date in the String format YYYY-MM-DD
   function formatDate(inputDate) {
     if (inputDate) {
@@ -72,6 +94,7 @@ function RegisterPatientRelationship(patientRelationship) {
         },
         select: function (event, ui) {
               setValue(patientRelationship.id + "-other_person_uuid", ui.item.data);
+              $(getInputElementFor(patientRelationship.id + "-field")).next(".field-error").remove();
               if (ui.item.data) {
                 setValue(patientRelationship.id + "-relationship_type",  patientRelationship.relationshipType + "-" + patientRelationship.relationshipDirection);
               } else {
@@ -83,35 +106,6 @@ function RegisterPatientRelationship(patientRelationship) {
           let element = getInputElementFor(fieldId);
           if ( !ui.item ) {
             setValue(patientRelationship.id + "-relationship_type", '');
-            if (getValue(fieldId).length > 0 ) {
-              if (typeof(NavigatorController) != 'undefined') {
-                let currentSection = selectedModel(NavigatorController.getSections());
-                let currentQuestion = selectedModel(NavigatorController.getQuestions());
-                var field = NavigatorController.getFieldById(fieldId);
-                if ( currentSection && currentQuestion ) {
-                  setTimeout(function () {
-                    let newSection = selectedModel(NavigatorController.getSections());
-                    let newQuestion = selectedModel(NavigatorController.getQuestions());
-                    if ( newQuestion ) {
-                      newQuestion.toggleSelection();
-                    }
-                    if ( newSection && newSection != currentSection) {
-                      newSection.toggleSelection();
-                      currentSection.toggleSelection();
-                    }
-                    currentQuestion.toggleSelection();
-                    if (field) {
-                      field.select();
-                    }
-                    $('<span class="field-error" style="">Invalid entry</span>').insertAfter('#' + patientRelationship.id + '-field');
-                  });
-                }
-              }
-            } else {
-              $(element).next(".field-error").remove();
-            }
-          } else {
-            $(element).next(".field-error").remove();
           }
         }
     });


### PR DESCRIPTION
@mogoodrich , I found an easier, more robust way of preventing the user from typing an incorrect person name. I just added an exit handler to the question(that's the reason i needed the question ID) and therefore I am able to prevent the user from moving away from the question if either the search box is not empty or a correct search result was not selected from the list:
![Screenshot 2023-10-31 at 9 58 30 AM](https://github.com/openmrs/openmrs-module-registrationapp/assets/1633285/ee388c8e-7655-458d-89ca-8c7d792856db)
