### PR TITLE
UHM-7545, disable address fields if no entries available

### DIFF
--- a/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
+++ b/omod/src/main/webapp/resources/scripts/field/personAddressWithHierarchy.js
@@ -322,6 +322,8 @@ function PersonAddressWithHierarchy(personAddressWithHierarchy) {
 
             // go to the first level we didn't just set
             var goToLevel = firstLevelNotIncluded(ui.item.data);
+            //this will disable next mandatory levels if no entries are configured in the system
+            preloadLevels(goToLevel);
 
             // if we are using the simple UI navigator, use the NavigatorController so that the simple for UI keeps up
             if (typeof(NavigatorController) != 'undefined') {


### PR DESCRIPTION
This would basically assure the same behavior as when manually selecting each field individually. The fields will be automatically be disabled if no entries are available in the system:
![Screenshot 2023-11-08 at 9 36 07 AM](https://github.com/openmrs/openmrs-module-registrationapp/assets/1633285/f2cf8d8a-9a75-4bef-aeff-485ba13e2f84)
