### PR TITLE
RA-2037: use mother's info to register a child

### DIFF
--- a/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/RegisterPatientFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/fragment/controller/RegisterPatientFragmentController.java
@@ -113,6 +113,7 @@ public class RegisterPatientFragmentController {
                             @RequestParam(value="registrationDate", required = false) Date registrationDate,
                             @RequestParam(value="unknown", required = false) Boolean unknown,
                             @RequestParam(value="patientIdentifier", required = false) String patientIdentifier,
+                            @RequestParam(value="returnUrl", required = false) String returnUrl,
                             HttpServletRequest request,
                             @SpringBean("messageSourceService") MessageSourceService messageSourceService,
                             @SpringBean("encounterService") EncounterService encounterService,
@@ -269,13 +270,16 @@ public class RegisterPatientFragmentController {
 
         InfoErrorMessageUtil.flashInfoMessage(request.getSession(), ui.message("registrationapp.createdPatientMessage", ui.encodeHtml(ui.format(patient))));
 
-        String redirectUrl = app.getConfig().get("afterCreatedUrl").getTextValue();
-        redirectUrl = redirectUrl.replaceAll("\\{\\{patientId\\}\\}", patient.getUuid());
-        if (registrationEncounter != null) {
-            redirectUrl = redirectUrl.replaceAll("\\{\\{encounterId\\}\\}", registrationEncounter.getId().toString());
+        if (StringUtils.isNotBlank(returnUrl)) {
+            return new SuccessResult(returnUrl);
+        } else {
+            String redirectUrl = app.getConfig().get("afterCreatedUrl").getTextValue();
+            redirectUrl = redirectUrl.replaceAll("\\{\\{patientId\\}\\}", patient.getUuid());
+            if (registrationEncounter != null) {
+                redirectUrl = redirectUrl.replaceAll("\\{\\{encounterId\\}\\}", registrationEncounter.getId().toString());
+            }
+            return new SuccessResult(redirectUrl);
         }
-
-        return new SuccessResult(redirectUrl);
     }
 
     private void parseObsGroup(Map<String, List<ObsGroupItem>> obsGroupMap, String param, String[] parameterValues) {

--- a/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
@@ -29,6 +29,7 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
     public void get(UiSessionContext sessionContext, PageModel model,
                     @RequestParam("appId") AppDescriptor app,
                     @RequestParam(value = "breadcrumbOverride", required = false) String breadcrumbOverride,
+                    @RequestParam(value="returnUrl", required=false) String returnUrl,
                     @RequestParam(value = "initialValues", required = false)  String initialValues,
                     @RequestParam(value = "mother", required = false)  Patient mother,
                     @ModelAttribute("patient") @BindParams Patient patient,
@@ -37,10 +38,10 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
                     UiUtils ui) throws Exception {
 
         sessionContext.requireAuthentication();
-        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, initialValues, mother,appFrameworkService, sessionContext);
+        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, returnUrl, initialValues, mother,appFrameworkService, sessionContext);
     }
 
-    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, String initialValues, Patient mother, AppFrameworkService appFrameworkService, UiSessionContext sessionContext) throws Exception {
+    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, String returnUrl, String initialValues, Patient mother, AppFrameworkService appFrameworkService, UiSessionContext sessionContext) throws Exception {
         NavigableFormStructure formStructure = RegisterPatientFormBuilder.buildFormStructure(app, app.getConfig().get("combineSections") != null ? app.getConfig().get("combineSections").getBooleanValue() : false,
                 appFrameworkService, sessionContext.generateAppContextModel());
 
@@ -69,6 +70,7 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
         model.addAttribute("enableOverrideOfAddressPortlet",
                 Context.getAdministrationService().getGlobalProperty("addresshierarchy.enableOverrideOfAddressPortlet", "false"));
         model.addAttribute("breadcrumbOverride", breadcrumbOverride);
+        model.addAttribute("returnUrl", returnUrl);
         model.addAttribute("initialFieldValues", initialValues);
         model.addAttribute("mother", mother);
         model.addAttribute("relationshipTypes", Context.getPersonService().getAllRelationshipTypes());

--- a/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/registrationapp/page/controller/RegisterPatientPageController.java
@@ -30,16 +30,17 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
                     @RequestParam("appId") AppDescriptor app,
                     @RequestParam(value = "breadcrumbOverride", required = false) String breadcrumbOverride,
                     @RequestParam(value = "initialValues", required = false)  String initialValues,
+                    @RequestParam(value = "mother", required = false)  Patient mother,
                     @ModelAttribute("patient") @BindParams Patient patient,
                     @SpringBean("emrApiProperties") EmrApiProperties emrApiProperties,
                     @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService,
                     UiUtils ui) throws Exception {
 
         sessionContext.requireAuthentication();
-        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, initialValues, appFrameworkService, sessionContext);
+        addModelAttributes(model, patient, app, emrApiProperties.getPrimaryIdentifierType(), breadcrumbOverride, initialValues, mother,appFrameworkService, sessionContext);
     }
 
-    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, String initialValues, AppFrameworkService appFrameworkService, UiSessionContext sessionContext) throws Exception {
+    public void addModelAttributes(PageModel model, Patient patient, AppDescriptor app, PatientIdentifierType primaryIdentifierType, String breadcrumbOverride, String initialValues, Patient mother, AppFrameworkService appFrameworkService, UiSessionContext sessionContext) throws Exception {
         NavigableFormStructure formStructure = RegisterPatientFormBuilder.buildFormStructure(app, app.getConfig().get("combineSections") != null ? app.getConfig().get("combineSections").getBooleanValue() : false,
                 appFrameworkService, sessionContext.generateAppContextModel());
 
@@ -69,6 +70,7 @@ public class RegisterPatientPageController extends AbstractRegistrationAppPageCo
                 Context.getAdministrationService().getGlobalProperty("addresshierarchy.enableOverrideOfAddressPortlet", "false"));
         model.addAttribute("breadcrumbOverride", breadcrumbOverride);
         model.addAttribute("initialFieldValues", initialValues);
+        model.addAttribute("mother", mother);
         model.addAttribute("relationshipTypes", Context.getPersonService().getAllRelationshipTypes());
 
         List<Extension> includeFragments = appFrameworkService.getExtensionsForCurrentUser("registerPatient.includeFragments");

--- a/omod/src/main/webapp/fragments/field/registerPersonRelationship.gsp
+++ b/omod/src/main/webapp/fragments/field/registerPersonRelationship.gsp
@@ -18,7 +18,7 @@
                 ${ config.label } <% if (config.classes && config.classes.join(' ').contains("required")) { %><span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span><% } %>
             </label>
 
-            <input type="text"  id="${ config.id }-field" class="searchablePerson" size="40" placeholder="${ui.message(ui.encodeHtmlAttribute('registrationapp.person.name'))}"/>
+            <input type="text"  id="${ config.id }-field" name="${ config.id }-field" class="searchablePerson" size="40" placeholder="${ui.message(ui.encodeHtmlAttribute('registrationapp.person.name'))}"/>
             <input type="hidden" name="other_person_uuid" id="${ config.id }-other_person_uuid"/>
             <input type="hidden" name="other_person_name" id="${ config.id }-other_person_name"/>
             <% if ( multipleValues ) { %>

--- a/omod/src/main/webapp/pages/registerPatient.gsp
+++ b/omod/src/main/webapp/pages/registerPatient.gsp
@@ -137,6 +137,10 @@ fieldset[id\$="-fieldset"] div > div {
                         if (NavigatorController.getQuestionById(questionName) != undefined) {
                             NavigatorController.getQuestionById(questionName).questionLi.addClass("done");
                         }
+                        if (fieldName == 'mother-field') {
+                            // otherwise the field's change() event that gets trigger automatically would clear the initial values which we just set above
+                            jq('#mother-field').autocomplete("option", "disabled", true);
+                        }
                     }
                 });
             }
@@ -385,6 +389,10 @@ fieldset[id\$="-fieldset"] div > div {
 
 	                                if (field.type == 'personAddress') {
 	                                    configOptions.addressTemplate = addressTemplate
+                                        // if a mother has been specified for this patient, then use the mother's address
+                                        if ( question.id == 'personAddressQuestion' && mother) {
+                                            configOptions.initialValue = mother.personAddress
+                                        }
 	                                }
 
 	                                if (field.type == 'personRelationships') {

--- a/omod/src/main/webapp/pages/registerPatient.gsp
+++ b/omod/src/main/webapp/pages/registerPatient.gsp
@@ -200,7 +200,9 @@ fieldset[id\$="-fieldset"] div > div {
     </div>
 
     <form class="simple-form-ui" id="registration" method="POST">
-
+        <p>
+            <input type="hidden" id="returnUrl" name="returnUrl" value="${ returnUrl }"/>
+        </p>
         <% if (includeRegistrationDateSection) { %>
         <section id="registration-info" class="non-collapsible">
             <span class="title">${ui.message("registrationapp.registrationDate.label")}</span>

--- a/omod/src/test/java/org/openmrs/module/registrationapp/fragment/controller/RegisterPatientFragmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/registrationapp/fragment/controller/RegisterPatientFragmentControllerTest.java
@@ -181,7 +181,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         request.addParameter("obs." + WEIGHT_CONCEPT_UUID, "70"); // this is WEIGHT (KG)
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, null, null, request,
+                patient, name, address, 30, null, null, null, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 
@@ -202,7 +202,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         request.addParameter("obs." + CIVIL_STATUS_CONCEPT_UUID, MARRIED_CONCEPT_UUID);
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, null, null, request,
+                patient, name, address, 30, null, null, null, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 
@@ -227,7 +227,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         request.addParameter("obs." + WEIGHT_CONCEPT_UUID, "70"); // this is WEIGHT (KG)
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, null, null, request,
+                patient, name, address, 30, null, null, null, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 
@@ -254,7 +254,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         name.setGivenName(null);
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, true, null, request,
+                patient, name, address, 30, null, null, true, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 
@@ -301,7 +301,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         request.addParameter("patientIdentifierField", "123abcd");
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, true, null, request,
+                patient, name, address, 30, null, null, true, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 
@@ -346,7 +346,7 @@ public class RegisterPatientFragmentControllerTest extends BaseModuleWebContextS
         request.addParameter("patientIdentifierField", "123abcd");
 
         FragmentActionResult result = controller.submit(sessionContext, app, registrationService,
-                patient, name, address, 30, null, null, true, null, request,
+                patient, name, address, 30, null, null, true, null, null, request,
                 messageSourceService, encounterService, obsService, conceptService, patientService, appFrameworkService, emrApiProperties,
                 patientValidator, uiUtils);
 


### PR DESCRIPTION
Because the person address widget and the relationships widget have onBlur() and onChange() events that get trigger automatically every time the form is displayed, I had to workaround those limitations when the mother info is included in the registration form. Thanks @mogoodrich for reviewing it!