### PR TITLE
RA-2037, update only the fields within the specified question

### DIFF
--- a/omod/src/main/webapp/pages/registerPatient.gsp
+++ b/omod/src/main/webapp/pages/registerPatient.gsp
@@ -132,11 +132,12 @@ fieldset[id\$="-fieldset"] div > div {
                     if (fieldProps && fieldProps.length == 3 ) {
                         //section.question.field
                         let fieldName = fieldProps[2];
-                        jq('input[name="' + fieldName + '"]').val(initialValues[field]);
                         let questionName = fieldProps[1];
+                        jq('#' + questionName + ' input[name="' + fieldName + '"]').val(initialValues[field]);
                         if (NavigatorController.getQuestionById(questionName) != undefined) {
                             NavigatorController.getQuestionById(questionName).questionLi.addClass("done");
                         }
+                        // when the relationships widget is configured to capture the mother info then the 'mother-field' will be present in the form
                         if (fieldName == 'mother-field') {
                             // otherwise the field's change() event that gets trigger automatically would clear the initial values which we just set above
                             jq('#mother-field').autocomplete("option", "disabled", true);


### PR DESCRIPTION
@mogoodrich , I have added the comment you requested about the 'mother-field' field. I have also updated the jQuery statement to only update the fields within the configured question. The relationship widget had two instances configured in out SL registration form, one for capturing the mother info, and another instance to capture the children. Therefore there were multiple fields with the name 'other_person_uuid' and that caused problems. So now I restrict the jQuery select statement to the field name within the given question name.