### PR TITLE
RA-2112: Bump major version to 2.0.0; upgrade uicommons dependency to…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>registrationapp</artifactId>
-		<version>1.30.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>registrationapp-api</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>registrationapp</artifactId>
-		<version>1.30.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>registrationapp-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>registrationapp</artifactId>
-	<version>1.30.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Registration App Module</name>
 	<description>Registration App for the Reference Application</description>
@@ -41,7 +41,7 @@
         <appframeworkVersion>2.15.0</appframeworkVersion>
         <springVersion>3.0.5.RELEASE</springVersion>
         <idgenVersion>4.4.0</idgenVersion>
-        <uicommonsVersion>2.4.0</uicommonsVersion>
+        <uicommonsVersion>3.2.0-SNAPSHOT</uicommonsVersion>
         <emrapiVersion>1.18</emrapiVersion>
         <calculationVersion>1.2</calculationVersion>
         <providerManagementVersion>2.5.0</providerManagementVersion>

--- a/web-1.9/pom.xml
+++ b/web-1.9/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>registrationapp</artifactId>
-        <version>1.30.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>registrationapp-web-1.9</artifactId>

--- a/web-2.0/pom.xml
+++ b/web-2.0/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>registrationapp</artifactId>
-        <version>1.30.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>registrationapp-web-2.0</artifactId>


### PR DESCRIPTION
… latest

I filed [https://openmrs.atlassian.net/browse/RA-2112](RA-2112) to add browser-side validation to required patient identifier in the registration app. However, Claude flagged that this change is dependent on a recent fix in `uicommons`. Since the current `uicommons` dependency is very old (~6 years), I think bumping registrationapp's major version while upgrading the `uicommons` dependency is the safe thing to do.